### PR TITLE
Main.java: Instantiate the SearchClient in a try-with-resources

### DIFF
--- a/java/src/main/java/Main.java
+++ b/java/src/main/java/Main.java
@@ -19,49 +19,48 @@ public class Main {
 
   public static void main(String[] args) throws ExecutionException, InterruptedException, IOException {
 
-    // Create a searchClient
-    SearchClient searchClient = new SearchClient(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1);
+    // Create a SearchClient (it's a Closeable, so you can leverage the try-with-resources construction
+    // to let the JVM close underlying resources when appropriate)
+    try (SearchClient searchClient = new SearchClient(ALGOLIA_APPLICATION_ID_1, ALGOLIA_API_KEY_1)) {
 
-    // Init an index
-    SearchIndex<Employee> index =
-        searchClient.initIndex("employees_" + System.getProperty("user.name"), Employee.class);
+      // Init an index
+      SearchIndex<Employee> index =
+              searchClient.initIndex("employees_" + System.getProperty("user.name"), Employee.class);
 
-    List<Employee> employees = hireEmployees();
-    CompletableFuture<BatchIndexingResponse> saveObjectsFuture = index.saveObjectsAsync(employees, true);
+      List<Employee> employees = hireEmployees();
+      CompletableFuture<BatchIndexingResponse> saveObjectsFuture = index.saveObjectsAsync(employees, true);
 
-    // Typed index
-    IndexSettings settings =
-        new IndexSettings()
-            .setAttributesForFaceting(Collections.singletonList("searchable(company)"));
+      // Typed index
+      IndexSettings settings =
+              new IndexSettings()
+                      .setAttributesForFaceting(Collections.singletonList("searchable(company)"));
 
-    // Typed request/response
-    CompletableFuture<SetSettingsResponse> setSettingsFuture = index.setSettingsAsync(settings);
+      // Typed request/response
+      CompletableFuture<SetSettingsResponse> setSettingsFuture = index.setSettingsAsync(settings);
 
-    // Calling get() is blocking on the future to be completed and waitTask is performing Algolia
-    // wait operations
-    saveObjectsFuture.get().waitTask();
-    setSettingsFuture.get().waitTask();
+      // Calling get() is blocking on the future to be completed and waitTask is performing Algolia
+      // wait operations
+      saveObjectsFuture.get().waitTask();
+      setSettingsFuture.get().waitTask();
 
-    // Performing multiple typed search asynchronously
-    CompletableFuture<SearchResult<Employee>> searchAlgoliaFuture =
-        index.searchAsync(new Query("algolia"));
+      // Performing multiple typed search asynchronously
+      CompletableFuture<SearchResult<Employee>> searchAlgoliaFuture =
+              index.searchAsync(new Query("algolia"));
 
-    SearchResult<Employee> search = index.search(new Query("algolia"));
+      SearchResult<Employee> search = index.search(new Query("algolia"));
 
-    CompletableFuture<SearchResult<Employee>> searchAppleFuture =
-        index.searchAsync(new Query("apple"));
+      CompletableFuture<SearchResult<Employee>> searchAppleFuture =
+              index.searchAsync(new Query("apple"));
 
-    CompletableFuture<SearchResult<Employee>> searchAmazonFuture =
-        index.searchAsync(new Query("amazon"));
+      CompletableFuture<SearchResult<Employee>> searchAmazonFuture =
+              index.searchAsync(new Query("amazon"));
 
-    CompletableFuture.allOf(searchAlgoliaFuture, searchAppleFuture, searchAmazonFuture);
+      CompletableFuture.allOf(searchAlgoliaFuture, searchAppleFuture, searchAmazonFuture);
 
-    System.out.println(searchAlgoliaFuture.get().getHits().get(0).getName());
-    System.out.println(searchAppleFuture.get().getHits().get(0).getName());
-    System.out.println(searchAmazonFuture.get().getHits().get(0).getName());
-
-    // You can close the underlying http client if you want to free resources.
-    searchClient.close();
+      System.out.println(searchAlgoliaFuture.get().getHits().get(0).getName());
+      System.out.println(searchAppleFuture.get().getHits().get(0).getName());
+      System.out.println(searchAmazonFuture.get().getHits().get(0).getName());
+    }
   }
 
   private static List<Employee> hireEmployees() {


### PR DESCRIPTION
Letting the JVM handle the closing of the underlying resources.

(the diff looks large due to the indentation mandated by the new outside block; check the diff without looking at spaces differences)