### PR TITLE
Main.java: Actually wait all searching futures before continuing

### DIFF
--- a/java/src/main/java/Main.java
+++ b/java/src/main/java/Main.java
@@ -55,7 +55,7 @@ public class Main {
       CompletableFuture<SearchResult<Employee>> searchAmazonFuture =
               index.searchAsync(new Query("amazon"));
 
-      CompletableFuture.allOf(searchAlgoliaFuture, searchAppleFuture, searchAmazonFuture);
+      CompletableFuture.allOf(searchAlgoliaFuture, searchAppleFuture, searchAmazonFuture).join();
 
       System.out.println(searchAlgoliaFuture.get().getHits().get(0).getName());
       System.out.println(searchAppleFuture.get().getHits().get(0).getName());


### PR DESCRIPTION
"allOf()" just creates a wrapper around a sequence of futures.
Invoking "join()" on it is required to effectively wait for all of the
futures to complete. Otherwise the wrapper would be unused - and here
the futures would be awaited for in sequence.