### PR TITLE
chore(dotnet): update TargetFrameworks to 3.x to match the readme

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -2,7 +2,7 @@
 
 ## .NET environment setup
 
-You can skip this part if you already have the .NET framework installed.
+You can skip this part if you already have the .NET Core 3.x framework installed.
 
 ### .NET Core SDK 3.x
 
@@ -52,5 +52,5 @@ dotnet build
 Then, run the project
 
 ```shell
-dotnet run
+ALGOLIA_APPLICATION_ID=<YOUR_APP_ID> ALGOLIA_ADMIN_API_KEY=<YOUR_API_KEY> dotnet run
 ```

--- a/dotnet/src/AlgoliaConsole/AlgoliaConsole.csproj
+++ b/dotnet/src/AlgoliaConsole/AlgoliaConsole.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
After following the instructions on a fresh environment, I got the following error when trying to run the project:

```sh
$ dotnet run
It was not possible to find any compatible framework version
The framework 'Microsoft.NETCore.App', version '2.0.0' was not found.
  - The following frameworks were found:
      3.1.19 at [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]

You can resolve the problem by installing the specified framework and/or SDK.
```

This PR updates the `<TargetFrameworks>` with all available 3.x versions to align with the readme.